### PR TITLE
Add basic neovim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ All available nodes are defined in the `grammar.js` or `src/node-types.json`.
 
 ## Install For Neovim
 
-Currently this parser is not ready to add to nvim-treesitter, so it will have to be installed manually.
+Currently this parser is not ready to add officially to nvim-treesitter, so it will have to be installed manually.
 
-First create `nvim/ftdetect/sourcepawn.vim` and put the following inside:
+First create `{YOUR_NVIM_CONFIG_DIR}/ftdetect/sourcepawn.vim` and put the following inside:
 ```vim
 function! s:setf(filetype) abort
     if &filetype !=# a:filetype
@@ -114,7 +114,9 @@ parser_config.sourcepawn = {
 }
 ```
 
-After that, run `:so` and `:TSInstall sourcepawn` (you may need to reload neovim first).
+After that, run `:so` and `:TSInstall sourcepawn` (you may need to reload neovim before these will work).
+
+Lastly, because this is unfortunately a manual install, you\'ll need to copy the query files from the repo\'s `queries` directory into your neovim\'s runtime path: `{YOUR_NVIM_CONFIG_DIR}/queries/sourcepawn/`
 
 ## Want to help?
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ console.log(tree.rootNode.toString());
 
 All available nodes are defined in the `grammar.js` or `src/node-types.json`.
 
+## Install For Neovim
+
+Currently this parser is not ready to add to nvim-treesitter, so it will have to be installed manually.
+
+First create `nvim/ftdetect/sourcepawn.vim` and put the following inside:
+```vim
+function! s:setf(filetype) abort
+    if &filetype !=# a:filetype
+        let &filetype = a:filetype
+    endif
+endfunction
+
+au BufNewFile,BufRead *.sp,*.sourcepawn,*.inc call s:setf('sourcepawn')
+```
+
+Next install [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter "nvim-treesitter"), then add the following to your config (init.lua):
+
+```lua
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+parser_config.sourcepawn = {
+  install_info = {
+    url = "https://github.com/Sarrus1/tree-sitter-sourcepawn",
+    files = {"src/parser.c", "src/scanner.c"},
+    branch = "main",
+    generate_requires_npm = false,
+    requires_generate_from_grammar = false,
+  },
+  filetype = "sp",
+}
+```
+
+After that, run `:so` and `:TSInstall sourcepawn` (you may need to reload neovim first).
+
 ## Want to help?
 
 You can help by writing tests which are not covered or valid Sourcepawn code, that fails parsing. Tests can be found in the `test` directory.

--- a/queries/context.scm
+++ b/queries/context.scm
@@ -1,0 +1,19 @@
+; For nvim-treesitter-context support
+
+(function_declaration) @context
+(condition_statement) @context
+(while_loop) @context
+(do_while_loop) @context
+(switch_statement) @context
+(switch_case) @context
+
+(methodmap) @context
+(methodmap_method_constructor) @context
+(methodmap_method) @context
+(methodmap_property) @context
+(methodmap_property_method) @context
+
+(enum_struct) @context
+(enum_struct_method) @context
+
+(typeset) @context

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -25,25 +25,41 @@
   name: (symbol) @variable)
 (variable_storage_class) @storageclass
 (this) @variable.builtin
-(escape_sequence) @punctuation.special
+(escape_sequence) @string.escape
+
+
+; Assume all uppercase symbols are constants
+((symbol) @constant
+  (#match? @constant "^[A-Z][A-Z\\d_]*$"))
 
 
 ; Preprocessor
 (preproc_include) @include
+(preproc_tryinclude) @include
 (system_lib_string) @string
 (string_literal) @string
 
+(preproc_assert) @preproc
 (preproc_pragma) @preproc
 (preproc_arg) @constant
 (preproc_macro) @function.macro
 (macro_param) @parameter
 (preproc_if) @preproc
 (preproc_else) @preproc
+(preproc_elseif) @preproc
 (preproc_endif) @preproc
 (preproc_endinput) @preproc
 (preproc_define) @define
 (preproc_define
   name: (symbol) @constant)
+(preproc_undefine) @define
+(preproc_undefine
+  name: (symbol) @constant)
+(preproc_error) @function.macro ; Wrong colour?
+(preproc_warning) @function.macro ; Wrong colour?
+
+; https://github.com/alliedmodders/sourcemod/blob/5c0ae11a4619e9cba93478683c7737253ea93ba6/plugins/include/handles.inc#L78
+(hardcoded_symbol) @variable.builtin
 
 
 ; Control-flow
@@ -55,6 +71,7 @@
 (switch_case) @conditional
 (switch_case_values) @constant
 (return_statement) @keyword.return
+(ternary_expression) @conditional.ternary
 
 
 ; Constructors (must be after function_call_arguments)
@@ -103,9 +120,11 @@
 
 
 ; Non-type Keywords
-[
-  "const"
-] @type.qualifier
+(variable_storage_class) @storageclass
+(variable_visibility) @storageclass
+(function_visibility) @storageclass
+(assertion) @function.builtin
+(function_definition_type) @keyword.function
 
 [
   "new"
@@ -113,19 +132,8 @@
 ] @keyword.operator
 
 [
-  "static"
-  "stock"
   "public" ; public Plugin myinfo
 ] @storageclass
-(function_visibility) @storageclass
-
-[
-  "native"
-  "forward"
-] @keyword.function ; I don't know if these count as storage classes or not
-
-; static_assert
-(assertion) @function.builtin
 
 [
   ";"
@@ -136,26 +144,44 @@
 
 ; Operators
 [
-  "--"
-  "-"
-  "-="
-  "="
-  "!="
-  "*"
-  "&"
-  "&&"
   "+"
-  "++"
-  "+="
+  "-"
+  "*"
+  "/"
   "%"
-  "<"
+  "++"
+  "--"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
   "=="
+  "!="
+  "<"
   ">"
+  ">="
+  "<="
+  "!"
+  "&&"
   "||"
+  "&"
+  "|"
   "~"
   "^"
-  "..."
+  "<<"
+  ">>"
+  ">>>"
+  "|="
+  "&="
+  "^="
+  "~="
+  "<<="
+  ">>="
 ] @operator
+(ignore_argument) @operator
+(scope_access) @operator
+(rest_operator) @operator ; Should override (concatenated_string) but currently does nothing
 
 
 ; public Plugin myinfo
@@ -185,6 +211,8 @@
 (char_literal) @character
 (float_literal) @float
 (string_literal) @string
+(array_literal) @punctuation.bracket
+(concatenated_string) @punctuation.delimiter ; Dots in string-literal concat--Doesn't seem to work?
 
 (null) @constant
 ((symbol) @constant

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,204 @@
+; General
+(symbol) @variable
+(type (builtin_type) @type.builtin)
+(builtin_type) @type.builtin
+(type (symbol) @type)
+(any_type) @type
+
+(function_definition
+  name: (symbol) @function)
+(function_call_arguments) @function.call
+(function_call
+  function: (symbol) @function.call)
+(argument_declarations) @parameter
+(argument_declaration
+  defaultValue: (symbol) @constant)
+
+(fixed_dimension) @punctuation.bracket ; the [3] in var[3]
+(dimension) @punctuation.bracket
+(array_indexed_access) @punctuation.bracket
+
+(sizeof_expression) @function.macro
+(view_as) @function.builtin
+(comment) @comment
+(variable_declaration
+  name: (symbol) @variable)
+(variable_storage_class) @storageclass
+(this) @variable.builtin
+(escape_sequence) @punctuation.special
+
+
+; Preprocessor
+(preproc_include) @include
+(system_lib_string) @string
+(string_literal) @string
+
+(preproc_pragma) @preproc
+(preproc_arg) @constant
+(preproc_macro) @function.macro
+(macro_param) @parameter
+(preproc_if) @preproc
+(preproc_else) @preproc
+(preproc_endif) @preproc
+(preproc_endinput) @preproc
+(preproc_define) @define
+(preproc_define
+  name: (symbol) @constant)
+
+
+; Control-flow
+(for_loop) @repeat
+(condition_statement) @conditional
+(while_loop) @repeat
+(do_while_loop) @repeat
+(switch_statement) @conditional
+(switch_case) @conditional
+(switch_case_values) @constant
+(return_statement) @keyword.return
+
+
+; Constructors (must be after function_call_arguments)
+(new_instance
+  class: (symbol) @type
+  arguments: (function_call_arguments) @constructor)
+  
+ 
+; Methods / Properties
+(field_access
+  field: (symbol) @field)
+
+(function_call
+  function: (field_access
+    field: (symbol) @method.call)) ; Must be after field_access
+
+
+; Methodmaps
+(methodmap) @type.definition
+(methodmap
+  name: (symbol) @type)
+(methodmap
+  inherits: (symbol) @type)
+
+(methodmap_method_constructor
+  name: (symbol) @constructor)
+(methodmap_method
+  name: (symbol) @method)
+(methodmap_native
+  name: (symbol) @method)
+
+(methodmap_property
+  name: (symbol) @property)
+(methodmap_property_getter) @method
+(methodmap_property_setter) @method
+
+
+; Enum structs
+(enum_struct) @type.definition
+(enum_struct
+  name: (symbol) @type)
+(enum_struct_field
+  name: (symbol) @field)
+(enum_struct_method
+  name: (symbol) @method)
+
+
+; Non-type Keywords
+[
+  "const"
+] @type.qualifier
+
+[
+  "new"
+  "delete"
+] @keyword.operator
+
+[
+  "static"
+  "stock"
+  "public" ; public Plugin myinfo
+] @storageclass
+(function_visibility) @storageclass
+
+[
+  "native"
+  "forward"
+] @keyword.function ; I don't know if these count as storage classes or not
+
+; static_assert
+(assertion) @function.builtin
+
+[
+  ";"
+  "."
+  ","
+] @punctuation.delimiter
+
+
+; Operators
+[
+  "--"
+  "-"
+  "-="
+  "="
+  "!="
+  "*"
+  "&"
+  "&&"
+  "+"
+  "++"
+  "+="
+  "%"
+  "<"
+  "=="
+  ">"
+  "||"
+  "~"
+  "^"
+  "..."
+] @operator
+
+
+; public Plugin myinfo
+(struct_declaration
+  name: (symbol) @variable.builtin)
+
+
+; Typedef/Typedef
+(typeset) @type.definition
+(typedef) @type.definition
+(typedef_expression) @keyword.function ; function void(int x)
+
+
+; Enums
+(enum) @type.definition
+(enum
+  name: (symbol) @type)
+(enum_entry
+  name: (symbol) @constant)
+(enum_entry
+  value: (_) @constant)
+
+
+; Literals
+(int_literal) @number
+(bool_literal) @boolean
+(char_literal) @character
+(float_literal) @float
+(string_literal) @string
+
+(null) @constant
+((symbol) @constant
+  (#match? @constant "INVALID_HANDLE"))
+
+
+; Comment specialisations (must be after comment)
+; These might be unnecessary and/or used incorrectly, since they're intended
+; for markup languages
+((comment) @text.todo
+  (#match? @text.todo "^\/[\/\*][\t ]TODO"))
+
+((comment) @text.note
+  (#match? @text.note "^\/[\/\*][\t ]NOTE"))
+  
+((comment) @text.warning
+  (#match? @text.warning "^\/[\/\*][\t ]WARNING"))

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,16 @@
+; I'm not super clear what this file is supposed to contain.
+; Seems like it defines scope and types of definitions to help treesitter
+; figure out highlighting even better?
+;
+; But it's not very clear what I should be putting here.
+
+;(function_declaration) @definition.function
+;(function_definition) @definition.function
+
+;(argument_declaration
+;  name: (symbol) @definition.parameter)
+
+;(variable_declaration
+;  name: (symbol) @definition.var)
+
+;(block) @scope


### PR DESCRIPTION
Adds highlighting support for about 95% of sourcepawn syntax (1.7+ only).
Additionally, adds support for [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context).

I'm not sure I've implemented it properly, and there may be some things here and there that aren't correct, but it's way better than nothing.
I checked through a bunch of stock sourcemod plugin files to see if I had missed any syntax and there's nothing I could find.

The `locals.scm` is essentially empty--I don't know how to write it properly or if it's even needed, but I left it there so it's not forgotten about in future, just in case.

I also added installation instructions added to the README but they should be reviewed by someone else because I have a suspicion it's going to be a case of "worked on my machine".